### PR TITLE
Update Golang Version for Dockerfile Closes #11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.8-alpine
+FROM golang:1.11-alpine
 # This container is for daily development.
 
 RUN apk add --no-cache build-base git libseccomp-dev linux-headers


### PR DESCRIPTION
Since [Dockerfile.builder-musllinux](https://github.com/lablup/backend.ai-jail/blob/main/Dockerfile.builder-musllinux) and [Dockerfile.builder-manylinux](https://github.com/lablup/backend.ai-jail/blob/main/Dockerfile.builder-manylinux) uses golang 1.11 version and [Dockerfile](https://github.com/lablup/backend.ai-jail/blob/main/Dockerfile) uses golang 1.8 version, I think the golang version for the Dockerfile should be updated to 1.11 version. This PR closes issue #11. 