### PR TITLE
Just a draft on why we need to update the README.md file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ attach jail-dev` to access its shell.
 
 Inside the container, you can use `go get`, `go build`, and so on seamlessly.
 
+*I think, this needs more explanation. The method to build the `backend.ai-jail` using `Makefile` is not specified. More explanations are also needed about the use case and the test.*
+
 To test the jail, run `./backend.ai-jail <policy-name> <command-args>`.
 Note that this jail binary cannot be executed outside the container even though
 it exists inside the working copy, if you use different OS/architectures for


### PR DESCRIPTION
> I think this needs more explanation. The method to build the backend.ai-jail using Makefile is not specified. More explanations are also needed about the use case and the test.

This commit doesn't include any additional info except the comment that I just wrote above. [I only made this commit since some kind of commit is needed to create a draft pull request.]

I will create another Draft pull request for changing the module structure. But I first wanted to run some simple examples, and I couldn't do it since the information on the provided readme file wasn't enough for me. 