### PR TITLE
Add configs for `arm64` dev-environment

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+	"go.toolsEnvVars": {
+		"GOOS" : "linux",
+		"GOARCH": "amd64",
+		"CGO_ENABLED": 1
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ build:
 	go build -tags netgo -ldflags '-extldflags "-static"' -v
 
 prepare-dev:
-	docker build -f Dockerfile -t jail-dev .
+	docker build -f Dockerfile -t jail-dev --platform linux/amd64 .
 	docker create -i -t -v "$(shell pwd)":$(CONTAINER_WORKDIR) -w $(CONTAINER_WORKDIR) --security-opt=seccomp:unconfined --name jail-dev jail-dev
 
 


### PR DESCRIPTION
This PR enables building `Jail` in arm64 machine with amd64 docker container,
and also enables developing the source code without compile errors in vscode.