### PR TITLE
[chore] Fix typo and remove redundant whitespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@
 
 A dynamic sandbox for Backend.Ai kernels.
 
-
 ## Testing and Debugging
 
- * Requirements: Docker, make
+* Requirements: Docker, make
 
-For this project, we use Go's module system - the Go's official depedency management system built into the go command.
+For this project, we use Go's module system - the Go's official dependency management system built into the go command.
 
 **To run:
 
@@ -15,7 +14,7 @@ Just run `make prepare-dev` to build and create a development container based
 on Alpine Linux.  Afterwards, you can `docker start jail-dev` and `docker
 attach jail-dev` to access its shell.
 
-Inside the container, run `make build`. This will build our backend.ai-jail. 
+Inside the container, run `make build`. This will build our backend.ai-jail.
 
 To test the jail, run `./backend.ai-jail <policy-name> <command-args>`.
 Note that this jail binary cannot be executed outside the container even though
@@ -23,7 +22,6 @@ it exists inside the working copy, if you use different OS/architectures for
 the host (e.g., macOS).
 
 To debug, add `-debug` flag to the command-line arguments.
-
 
 ## Building Release Binaries
 

--- a/main.go
+++ b/main.go
@@ -2,11 +2,13 @@
 
 /*
 Command-line usage:
-	./jail <child_args ...>  // use default policy
-	./jail -policy <policy_file> <child_args ...>
+
+	./backend.ai-jail <child_args ...>  // use default policy
+	./backend.ai-jail -policy <policy_file> <child_args ...>
 
 Example:
-	./jail -policy python3.yml /bin/sh /home/backend.ai/run.sh
+
+	./backend.ai-jail -policy python3.yml /bin/sh /home/backend.ai/run.sh
 */
 package main
 


### PR DESCRIPTION
* Fix typo and remove redundant whitespaces
* Rename jail to backend.ai-jail in main.go's command-line usage