### PR TITLE
feat: Add finding executable feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "serde_yaml",
  "signal-hook",
  "tokio",
+ "which",
 ]
 
 [[package]]
@@ -233,6 +234,12 @@ dependencies = [
  "rustc_version",
  "syn",
 ]
+
+[[package]]
+name = "either"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "errno"
@@ -908,6 +915,17 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "which"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c831fbbee9e129a8cf93e7747a82da9d95ba8e16621cae60ec2cdc849bacb7b"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
+]
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ log = "0.4"
 fern = { version = "0.6", features = ["colored"] }
 chrono = "0.4"
 libloading = "0.7"
+which = "4.3.0"

--- a/src/jail.rs
+++ b/src/jail.rs
@@ -18,6 +18,7 @@ use std::path::PathBuf;
 use std::process::{exit, id as getpid, Command};
 use std::{env, fs};
 use tokio::signal::unix::{signal as tokioSignal, SignalKind};
+use which::which;
 
 pub struct Jail {
     policy_inst: FileBasedPolicy,
@@ -764,10 +765,8 @@ impl Jail {
             panic_if_err!(filter.load());
         }
 
-        let bin_path = PathBuf::from(&self.cli.args[0]);
-        if !bin_path.exists() {
-            panic!("{} not found", self.cli.args[0]);
-        }
+        let bin_path =
+            which(&self.cli.args[0]).unwrap_or_else(|_| panic!("{} not found", self.cli.args[0]));
 
         let error = Command::new(&bin_path)
             .args(self.cli.args.get_mut(1..).unwrap())


### PR DESCRIPTION
Fixes #34 using [which](https://crates.io/crates/which) crate.

## Result 

```
root@436c20aa0dbc:/src# target/debug/backendai-jail python3
2023-01-19 01:43:13.064642 WARN backendai_jail::jail [7] error while tracing syscall killpg: Could not resolve syscall name killpg
Python 3.9.2 (default, Feb 28 2021, 17:03:44) 
[GCC 10.2.1 20210110] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> ```